### PR TITLE
Get rid of heroku-run-build-script

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,6 +98,5 @@
   "bugs": {
     "url": "https://github.com/Bernd-L/exDateMan/issues"
   },
-  "homepage": "https://github.com/Bernd-L/exDateMan#readme",
-  "heroku-run-build-script": true
+  "homepage": "https://github.com/Bernd-L/exDateMan#readme"
 }


### PR DESCRIPTION
The "heroku-run-build-script"-key isn't required anymore.
This commit removes it.